### PR TITLE
chore: speakeasy migrate

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -1,30 +1,25 @@
 name: Generate
 permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
+    checks: write
+    contents: write
+    pull-requests: write
+    statuses: write
 "on":
-  workflow_dispatch:
-    inputs:
-      force:
-        description: Force generation of SDKs
-        type: boolean
-        default: false
-  schedule:
-    - cron: 0 0 * * *
+    workflow_dispatch:
+        inputs:
+            force:
+                description: Force generation of SDKs
+                type: boolean
+                default: false
+    schedule:
+        - cron: 0 0 * * *
 jobs:
-  generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14
-    with:
-      force: ${{ github.event.inputs.force }}
-      languages: |
-        - typescript
-      mode: pr
-      publish_typescript: false
-      openapi_docs: |
-        - https://insulator.conductor.one/api/v1/openapi.yaml
-      speakeasy_version: latest
-    secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+    generate:
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+        with:
+            force: ${{ github.event.inputs.force }}
+            mode: pr
+            speakeasy_version: latest
+        secrets:
+            github_access_token: ${{ secrets.GITHUB_TOKEN }}
+            speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/speakeasy_sdk_publish.yml
+++ b/.github/workflows/speakeasy_sdk_publish.yml
@@ -1,15 +1,18 @@
 name: Publish
+permissions:
+    checks: write
+    contents: write
+    pull-requests: write
+    statuses: write
 "on":
-  push:
-    branches:
-      - main
-    paths:
-      - RELEASES.md
+    push:
+        branches:
+            - main
+        paths:
+            - RELEASES.md
 jobs:
-  publish:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14
-    with:
-      create_release: true
-    secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+    publish:
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+        secrets:
+            github_access_token: ${{ secrets.GITHUB_TOKEN }}
+            speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,0 +1,9 @@
+workflowVersion: 1.0.0
+sources:
+    my-source:
+        inputs:
+            - location: https://insulator.conductor.one/api/v1/openapi.yaml
+targets:
+    conductorone-ts:
+        target: typescript
+        source: my-source


### PR DESCRIPTION
This PR is the set of changes created from speakeasy migrate . Docs here: https://www.speakeasyapi.dev/docs/workflow-migration

Merging this migration enables:

-Local use of `speakeasy run` which emulates github generation locally
-linting reports
-breaking change reports on API changes

No code changes as a result of this migration

