### PR TITLE
chore: remove axios dependency in favor of native fetch

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -34,7 +34,6 @@ typescript:
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies:
-      axios: ^1.8.4
       jose: ^6.0.0
     devDependencies:
       '@types/jest': ^29.0.0

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "typescript-eslint": "^8.26.0"
   },
   "dependencies": {
-    "axios": "^1.8.4",
     "jose": "^6.0.0",
     "zod": "^3.25.0 || ^4.0.0"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,9 +1,10 @@
 import { ConductoroneSDKTypescript as ConductoroneSDKTypescript_orig } from "./sdk/sdk";
 import { SDKOptions } from "./lib/config";
+import { HTTPClient } from "./lib/http";
 export interface SDKProps extends SDKOptions {
     clientID?: string;
     clientSecret?: string;
-    defaultClient?: any;
+    defaultClient?: HTTPClient;
 }
 export declare class ConductoroneSDKTypescript extends ConductoroneSDKTypescript_orig {
     private tokenCache;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { Token } from "./token";
 import { ConductoroneSDKTypescript as ConductoroneSDKTypescript_orig } from "./sdk/sdk";
 import { ServerList } from "./lib/config";
@@ -17,13 +16,16 @@ export class ConductoroneSDKTypescript extends ConductoroneSDKTypescript_orig {
             httpClient,
             userAgent: "conductorone-sdk-typescript/1.1.0",
             ...(props?.debugLogger && { debugLogger: props.debugLogger }),
-            security: async () => ({
-                bearerAuth: getTokenFn ? await getTokenFn() : "",
-                oauth: "",
-            }),
+            security: async () => {
+                const token = getTokenFn ? await getTokenFn() : "";
+                return {
+                    bearerAuth: token,
+                    oauth: token,
+                };
+            },
         });
+        this.tokenClient = httpClient;
         if (props?.clientID && props?.clientSecret) {
-            this.tokenClient = props?.defaultClient ?? axios.create({ baseURL: serverURL });
             this.token = new Token(this.tokenClient, serverURL, props.clientID, props.clientSecret);
             getTokenFn = this.getValidToken.bind(this);
         }
@@ -40,6 +42,7 @@ export class ConductoroneSDKTypescript extends ConductoroneSDKTypescript_orig {
         }
         catch (error) {
             console.error('Failed to get initial token:', error);
+            throw error;
         }
     }
     getCurrentToken() {
@@ -54,7 +57,10 @@ export class ConductoroneSDKTypescript extends ConductoroneSDKTypescript_orig {
         if (!this.tokenCache || now >= this.tokenCache.expiresAt) {
             await this.getAndCacheToken();
         }
-        return this.tokenCache?.token || '';
+        if (!this.tokenCache?.token) {
+            throw new Error('Failed to obtain auth token');
+        }
+        return this.tokenCache.token;
     }
 }
 export { ServerList } from "./lib/config";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { Token } from "./token.js";
 import { ConductoroneSDKTypescript as ConductoroneSDKTypescript_orig } from "./sdk/sdk.js";
 import { ServerList, SDKOptions } from "./lib/config.js";
@@ -7,12 +6,12 @@ import { HTTPClient } from "./lib/http.js";
 export interface SDKProps extends SDKOptions {
   clientID?: string;
   clientSecret?: string;
-  defaultClient?: any;
+  defaultClient?: HTTPClient;
 }
 
 export class ConductoroneSDKTypescript extends ConductoroneSDKTypescript_orig {
   private tokenCache: { token: string; expiresAt: number } | null = null;
-  private tokenClient: any;
+  private tokenClient: HTTPClient;
   private token: Token | null = null;
 
   constructor(props?: SDKProps) {
@@ -37,8 +36,9 @@ export class ConductoroneSDKTypescript extends ConductoroneSDKTypescript_orig {
       },
     });
 
+    this.tokenClient = httpClient;
+
     if (props?.clientID && props?.clientSecret) {
-      this.tokenClient = props?.defaultClient ?? axios.create({ baseURL: serverURL });
       this.token = new Token(this.tokenClient, serverURL, props.clientID, props.clientSecret);
       getTokenFn = this.getValidToken.bind(this);
     }

--- a/src/token.d.ts
+++ b/src/token.d.ts
@@ -1,9 +1,9 @@
-import { AxiosInstance } from "axios";
+import { HTTPClient } from "./lib/http";
 export declare class Token {
     private readonly tokenUrl;
     private readonly clientID;
     private readonly clientSecret;
-    private defaultClient;
-    constructor(defaultClient: AxiosInstance, tokenUrl: string, clientID: string, clientSecret: string);
+    private httpClient;
+    constructor(httpClient: HTTPClient, tokenUrl: string, clientID: string, clientSecret: string);
     getToken(): Promise<string>;
 }

--- a/src/token.js
+++ b/src/token.js
@@ -6,12 +6,12 @@ export class Token {
     tokenUrl;
     clientID;
     clientSecret;
-    defaultClient;
-    constructor(defaultClient, tokenUrl, clientID, clientSecret) {
+    httpClient;
+    constructor(httpClient, tokenUrl, clientID, clientSecret) {
         this.tokenUrl = tokenUrl;
         this.clientID = clientID;
         this.clientSecret = clientSecret;
-        this.defaultClient = defaultClient;
+        this.httpClient = httpClient;
     }
     async getToken() {
         const [name, domain, version, secret] = this.clientSecret.split(':');
@@ -59,14 +59,20 @@ export class Token {
             client_assertion: tokenStr,
         };
         const tokenUrl = new URL(`${this.tokenUrl}/auth/v1/token`);
-        const resp = await this.defaultClient.post(tokenUrl.toString(), new URLSearchParams(body), {
+        const req = new Request(tokenUrl.toString(), {
+            method: 'POST',
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
+            body: new URLSearchParams(body).toString(),
         });
+        const resp = await this.httpClient.request(req);
         if (resp.status !== 200) {
             throw new Error(`Failed to get token: ${resp.status}`);
         }
-        return resp.data.access_token;
+        const data = await resp.json();
+        const raw = String(data?.access_token ?? "");
+        const normalized = raw.replace(/^\s*bearer\s*:*/i, "").trim();
+        return normalized;
     }
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,7 +1,7 @@
 import * as jose from 'jose'
 import {URLSearchParams} from 'url';
-import {AxiosInstance} from "axios";
 import * as crypto from 'crypto';
+import { HTTPClient } from './lib/http.js';
 
 const assertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
@@ -9,13 +9,13 @@ export class Token {
     private readonly tokenUrl: string;
     private readonly clientID: string;
     private readonly clientSecret: string;
-    private defaultClient: AxiosInstance;
+    private httpClient: HTTPClient;
 
-    constructor(defaultClient: AxiosInstance, tokenUrl: string, clientID: string, clientSecret: string) {
+    constructor(httpClient: HTTPClient, tokenUrl: string, clientID: string, clientSecret: string) {
         this.tokenUrl = tokenUrl;
         this.clientID = clientID;
         this.clientSecret = clientSecret;
-        this.defaultClient = defaultClient;
+        this.httpClient = httpClient;
     }
 
     async getToken(): Promise<string> {
@@ -71,20 +71,22 @@ export class Token {
 
         const tokenUrl = new URL(`${this.tokenUrl}/auth/v1/token`);
 
-        const resp = await this.defaultClient.post(
-            tokenUrl.toString(),
-            new URLSearchParams(body),
-            {
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
-            });
+        const req = new Request(tokenUrl.toString(), {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams(body).toString(),
+        });
+
+        const resp = await this.httpClient.request(req);
 
         if (resp.status !== 200) {
             throw new Error(`Failed to get token: ${resp.status}`);
         }
 
-        const raw = String(resp.data?.access_token ?? "");
+        const data = await resp.json() as { access_token?: unknown };
+        const raw = String(data?.access_token ?? "");
         const normalized = raw.replace(/^\s*bearer\s*:*/i, "").trim();
         return normalized;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,24 +1315,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asynckit@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "asynckit@npm:0.4.0"
-  checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.8.4":
-  version: 1.13.1
-  resolution: "axios@npm:1.13.1"
-  dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.4"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/de9c3c6de43d3ee1146d3afe78645f19450cac6a5d7235bef8b8e8eeb705c2e47e2d231dea99cecaec4dae1897c521118ca9413b9d474063c719c4d94c5b9adc
-  languageName: node
-  linkType: hard
-
 "babel-jest@npm:^29.7.0":
   version: 29.7.0
   resolution: "babel-jest@npm:29.7.0"
@@ -1502,16 +1484,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "call-bind-apply-helpers@npm:1.0.2"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    function-bind: "npm:^1.1.2"
-  checksum: 10c0/47bd9901d57b857590431243fea704ff18078b16890a6b3e021e12d279bbf211d039155e27d7566b374d49ee1f8189344bac9833dec7a20cdec370506361c938
-  languageName: node
-  linkType: hard
-
 "callsites@npm:^3.0.0":
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
@@ -1635,15 +1607,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "combined-stream@npm:1.0.8"
-  dependencies:
-    delayed-stream: "npm:~1.0.0"
-  checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
-  languageName: node
-  linkType: hard
-
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -1659,7 +1622,6 @@ __metadata:
     "@types/jest": "npm:^29.0.0"
     "@types/node": "npm:^18.19.0"
     "@types/reflect-metadata": "npm:^0.1.0"
-    axios: "npm:^1.8.4"
     dotenv: "npm:^16.4.7"
     eslint: "npm:^9.26.0"
     globals: "npm:^15.14.0"
@@ -1748,13 +1710,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"delayed-stream@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "delayed-stream@npm:1.0.0"
-  checksum: 10c0/d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
-  languageName: node
-  linkType: hard
-
 "detect-newline@npm:^3.0.0":
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
@@ -1773,17 +1728,6 @@ __metadata:
   version: 16.6.1
   resolution: "dotenv@npm:16.6.1"
   checksum: 10c0/15ce56608326ea0d1d9414a5c8ee6dcf0fffc79d2c16422b4ac2268e7e2d76ff5a572d37ffe747c377de12005f14b3cc22361e79fc7f1061cce81f77d2c973dc
-  languageName: node
-  linkType: hard
-
-"dunder-proto@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "dunder-proto@npm:1.0.1"
-  dependencies:
-    call-bind-apply-helpers: "npm:^1.0.1"
-    es-errors: "npm:^1.3.0"
-    gopd: "npm:^1.2.0"
-  checksum: 10c0/199f2a0c1c16593ca0a145dbf76a962f8033ce3129f01284d48c45ed4e14fea9bbacd7b3610b6cdc33486cef20385ac054948fefc6272fcce645c09468f93031
   languageName: node
   linkType: hard
 
@@ -1821,41 +1765,6 @@ __metadata:
   dependencies:
     is-arrayish: "npm:^0.2.1"
   checksum: 10c0/ba827f89369b4c93382cfca5a264d059dfefdaa56ecc5e338ffa58a6471f5ed93b71a20add1d52290a4873d92381174382658c885ac1a2305f7baca363ce9cce
-  languageName: node
-  linkType: hard
-
-"es-define-property@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "es-define-property@npm:1.0.1"
-  checksum: 10c0/3f54eb49c16c18707949ff25a1456728c883e81259f045003499efba399c08bad00deebf65cccde8c0e07908c1a225c9d472b7107e558f2a48e28d530e34527c
-  languageName: node
-  linkType: hard
-
-"es-errors@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "es-errors@npm:1.3.0"
-  checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
-  languageName: node
-  linkType: hard
-
-"es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "es-object-atoms@npm:1.1.1"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-  checksum: 10c0/65364812ca4daf48eb76e2a3b7a89b3f6a2e62a1c420766ce9f692665a29d94fe41fe88b65f24106f449859549711e4b40d9fb8002d862dfd7eb1c512d10be0c
-  languageName: node
-  linkType: hard
-
-"es-set-tostringtag@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "es-set-tostringtag@npm:2.1.0"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    get-intrinsic: "npm:^1.2.6"
-    has-tostringtag: "npm:^1.0.2"
-    hasown: "npm:^2.0.2"
-  checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
   languageName: node
   linkType: hard
 
@@ -2169,35 +2078,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.6":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
-  languageName: node
-  linkType: hard
-
 "foreground-child@npm:^4.0.0":
   version: 4.0.3
   resolution: "foreground-child@npm:4.0.3"
   dependencies:
     signal-exit: "npm:^4.0.1"
   checksum: 10c0/bc4964f92478ff17bac24d875e894e02131a369604a8339b8137c7dfdc38f0e4423eddb35583f417b89b01845507bfb318b149d2428aba65b43880f2214dc416
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "form-data@npm:4.0.4"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/373525a9a034b9d57073e55eab79e501a714ffac02e7a9b01be1c820780652b16e4101819785e1e18f8d98f0aee866cc654d660a435c378e16a72f2e7cac9695
   languageName: node
   linkType: hard
 
@@ -2248,38 +2134,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.6":
-  version: 1.3.0
-  resolution: "get-intrinsic@npm:1.3.0"
-  dependencies:
-    call-bind-apply-helpers: "npm:^1.0.2"
-    es-define-property: "npm:^1.0.1"
-    es-errors: "npm:^1.3.0"
-    es-object-atoms: "npm:^1.1.1"
-    function-bind: "npm:^1.1.2"
-    get-proto: "npm:^1.0.1"
-    gopd: "npm:^1.2.0"
-    has-symbols: "npm:^1.1.0"
-    hasown: "npm:^2.0.2"
-    math-intrinsics: "npm:^1.1.0"
-  checksum: 10c0/52c81808af9a8130f581e6a6a83e1ba4a9f703359e7a438d1369a5267a25412322f03dcbd7c549edaef0b6214a0630a28511d7df0130c93cfd380f4fa0b5b66a
-  languageName: node
-  linkType: hard
-
 "get-package-type@npm:^0.1.0":
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
   checksum: 10c0/e34cdf447fdf1902a1f6d5af737eaadf606d2ee3518287abde8910e04159368c268568174b2e71102b87b26c2020486f126bfca9c4fb1ceb986ff99b52ecd1be
-  languageName: node
-  linkType: hard
-
-"get-proto@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "get-proto@npm:1.0.1"
-  dependencies:
-    dunder-proto: "npm:^1.0.1"
-    es-object-atoms: "npm:^1.0.0"
-  checksum: 10c0/9224acb44603c5526955e83510b9da41baf6ae73f7398875fba50edc5e944223a89c4a72b070fcd78beb5f7bdda58ecb6294adc28f7acfc0da05f76a2399643c
   languageName: node
   linkType: hard
 
@@ -2347,13 +2205,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gopd@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "gopd@npm:1.2.0"
-  checksum: 10c0/50fff1e04ba2b7737c097358534eacadad1e68d24cccee3272e04e007bed008e68d2614f3987788428fd192a5ae3889d08fb2331417e4fc4a9ab366b2043cead
-  languageName: node
-  linkType: hard
-
 "graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
@@ -2390,22 +2241,6 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
-  languageName: node
-  linkType: hard
-
-"has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "has-symbols@npm:1.1.0"
-  checksum: 10c0/dde0a734b17ae51e84b10986e651c664379018d10b91b6b0e9b293eddb32f0f069688c841fb40f19e9611546130153e0a2a48fd7f512891fb000ddfa36f5a20e
-  languageName: node
-  linkType: hard
-
-"has-tostringtag@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "has-tostringtag@npm:1.0.2"
-  dependencies:
-    has-symbols: "npm:^1.0.3"
-  checksum: 10c0/a8b166462192bafe3d9b6e420a1d581d93dd867adb61be223a17a8d6dad147aa77a8be32c961bb2f27b3ef893cae8d36f564ab651f5e9b7938ae86f74027c48c
   languageName: node
   linkType: hard
 
@@ -3275,13 +3110,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"math-intrinsics@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "math-intrinsics@npm:1.1.0"
-  checksum: 10c0/7579ff94e899e2f76ab64491d76cf606274c874d8f2af4a442c016bd85688927fcfca157ba6bf74b08e9439dc010b248ce05b96cc7c126a354c3bae7fcb48b7f
-  languageName: node
-  linkType: hard
-
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -3303,22 +3131,6 @@ __metadata:
     braces: "npm:^3.0.3"
     picomatch: "npm:^2.3.1"
   checksum: 10c0/166fa6eb926b9553f32ef81f5f531d27b4ce7da60e5baf8c021d043b27a388fb95e46a8038d5045877881e673f8134122b59624d5cecbd16eb50a42e7a6b5ca8
-  languageName: node
-  linkType: hard
-
-"mime-db@npm:1.52.0":
-  version: 1.52.0
-  resolution: "mime-db@npm:1.52.0"
-  checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
-  languageName: node
-  linkType: hard
-
-"mime-types@npm:^2.1.12":
-  version: 2.1.35
-  resolution: "mime-types@npm:2.1.35"
-  dependencies:
-    mime-db: "npm:1.52.0"
-  checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
   languageName: node
   linkType: hard
 
@@ -3687,13 +3499,6 @@ __metadata:
     kleur: "npm:^3.0.3"
     sisteransi: "npm:^1.0.5"
   checksum: 10c0/16f1ac2977b19fe2cf53f8411cc98db7a3c8b115c479b2ca5c82b5527cd937aa405fa04f9a5960abeb9daef53191b53b4d13e35c1f5d50e8718c76917c5f1ea4
-  languageName: node
-  linkType: hard
-
-"proxy-from-env@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "proxy-from-env@npm:1.1.0"
-  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Removes `axios` and its 25 transitive deps (form-data, follow-redirects, etc.) from the install tree
- The Speakeasy-generated SDK already uses `fetch` via `HTTPClient` — axios was a redundant second HTTP stack used only for a single token-fetch POST
- Shares a single `HTTPClient` instance between the SDK and the token client; no more dual-purpose `defaultClient`

## Why

Axios was only used in two hand-written files (`src/index.ts`, `src/token.ts`, both in `.genignore`) for the OAuth2 client-credentials POST to `/auth/v1/token`. Speakeasy's TypeScript SDK methodology [explicitly uses `fetch`](https://www.speakeasy.com/docs/sdk-design/typescript/methodology-ts) and never required axios; it was a manual addition under `typescript.additionalDependencies` in `.speakeasy/gen.yaml`.

Benefits:
- Smaller install footprint (axios ≈ 30KB min+gz + transitive deps)
- One HTTP abstraction instead of two — token requests now flow through the SDK's `beforeRequest`/`response` hooks
- Better runtime portability (fetch works uniformly in browsers, Node 18+, Bun, Deno, edge runtimes)

## Changes

| File | Change |
|---|---|
| `src/token.ts` | Replaced `AxiosInstance` with `HTTPClient`. POST uses `new Request(...)` + `httpClient.request()` + `resp.json()`. |
| `src/index.ts` | Removed `import axios`. Shares the SDK's `HTTPClient` with the token client. |
| `src/token.d.ts` / `src/index.d.ts` | Updated type declarations; `defaultClient?: HTTPClient` (was `any`). |
| `src/token.js` / `src/index.js` | Refreshed committed JS artifacts. |
| `package.json` | Removed `"axios": "^1.8.4"` from `dependencies`. |
| `.speakeasy/gen.yaml` | Removed axios from `typescript.additionalDependencies.dependencies` so regen does not re-add it. |
| `yarn.lock` | Regenerated; axios + 25 transitive deps removed. |

## Public API impact

`SDKProps.defaultClient` is narrowed from `any` to `HTTPClient`. Callers passing nothing are unaffected. Anyone previously passing a custom axios instance must now pass an `HTTPClient` (importable from `conductorone-sdk-typescript/lib/http`).

## Verification

- `yarn install` — 413 packages, axios absent from `node_modules`
- `yarn lint` — 0 errors, 0 warnings
- `yarn build` — exit 0; built `dist/esm` and `dist/commonjs`; output contains zero axios references
- `yarn tsc --noEmit` — same 97 pre-existing errors as `main` (all in stale committed `.js` files unrelated to this change); zero new errors; none in edited files

Net diff: **+48 / −230 lines** (real source change is ~10 lines; the rest is yarn.lock cleanup).