### PR TITLE
chore: bump version to 1.2.2

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: 0.1.0-alpha
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
-  releaseVersion: 1.2.0
+  releaseVersion: 1.2.2
   configChecksum: e2d9a0afa6891e2055eb42e87343960f
   repoURL: https://github.com/ConductorOne/conductorone-sdk-typescript.git
   installationURL: https://github.com/ConductorOne/conductorone-sdk-typescript

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -30,7 +30,7 @@ generation:
     skipResponseBodyAssertions: false
   baseServerURL: ""
 typescript:
-  version: 1.2.0
+  version: 1.2.2
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conductorone-sdk-typescript",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "author": "ConductorOne",
   "type": "module",
   "tshy": {


### PR DESCRIPTION
## Summary
- Bumps `package.json` from 1.2.0 → 1.2.2
- Bumps `.speakeasy/gen.yaml` `typescript.version` from 1.2.0 → 1.2.2
- Bumps `.speakeasy/gen.lock` `management.releaseVersion` from 1.2.0 → 1.2.2

## Why
The `v1.2.1` and `v1.2.2` tags were placed on commits that did not bump the version field, so the published package would still have been labelled 1.2.0. The manual `workflow_dispatch` run against `v1.2.2` ([run 26112976735](https://github.com/ConductorOne/conductorone-sdk-typescript/actions/runs/26112976735)) confirmed this — it attempted to publish `conductorone-sdk-typescript@1.2.0`. (It also failed on a 404/permission error from the npm registry, which is a separate issue — the `NPM_TOKEN` secret does not have publish rights on the npm package. The last successful publish was 1.1.1 in October 2025.)

## ⚠️ Before merging
This PR touches `.speakeasy/gen.lock`, which is the path that triggers `sdk_publish.yaml` on push to `main`. **Merging will auto-fire the publish workflow.** That workflow will fail again with the same npm 404 unless `NPM_TOKEN` is fixed first:
- Confirm `NPM_TOKEN` in repo secrets is an automation / granular token whose owner has publish rights on the `conductorone-sdk-typescript` npm package.
- After merging, watch the run; on success the package will be `conductorone-sdk-typescript@1.2.2`.

Note: the workflow does **not** trigger on tag pushes — only on changes to `.speakeasy/gen.lock` or manual dispatch. That is why simply tagging `v1.2.2` did nothing originally.

## Test plan
- [ ] Verify `NPM_TOKEN` secret has publish rights on the npm package before merge
- [ ] After merge, confirm `sdk_publish.yaml` run succeeds against `main`
- [ ] Confirm `npm view conductorone-sdk-typescript version` returns `1.2.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)