### PR TITLE
fix: allow null for App.appUserMapper

### DIFF
--- a/overlay.yaml
+++ b/overlay.yaml
@@ -277,6 +277,13 @@ actions:
       - "null"
   - target: $["components"]["schemas"]["c1.api.app.v1.App"]["properties"]["appOwners"]["nullable"]
     remove: true
+  - target: $["components"]["schemas"]["c1.api.app.v1.App"]["properties"]["appUserMapper"]
+    update:
+      oneOf:
+        - $ref: '#/components/schemas/c1.api.app.v1.AppUserMapper'
+        - type: "null"
+  - target: $["components"]["schemas"]["c1.api.app.v1.App"]["properties"]["appUserMapper"]["$ref"]
+    remove: true
   - target: $["components"]["schemas"]["c1.api.app.v1.App"]["properties"]["certifyPolicyId"]["type"]
     update:
       - string

--- a/src/sdk/models/shared/app.ts
+++ b/src/sdk/models/shared/app.ts
@@ -76,7 +76,7 @@ export type App = {
   /**
    * AppUserMapper configures custom account mapping for uplift.
    */
-  appUserMapper?: AppUserMapper | undefined;
+  appUserMapper?: AppUserMapper | null | undefined;
   /**
    * The ID of the Certify Policy associated with this App.
    */
@@ -173,7 +173,7 @@ export type AppInput = {
   /**
    * AppUserMapper configures custom account mapping for uplift.
    */
-  appUserMapper?: AppUserMapper | undefined;
+  appUserMapper?: AppUserMapper | null | undefined;
   /**
    * The ID of the Certify Policy associated with this App.
    */
@@ -269,7 +269,7 @@ export const App$inboundSchema: z.ZodType<App, z.ZodTypeDef, unknown> = z
     appAccountId: z.nullable(z.string()).optional(),
     appAccountName: z.nullable(z.string()).optional(),
     appOwners: z.nullable(z.array(User$inboundSchema)).optional(),
-    appUserMapper: AppUserMapper$inboundSchema.optional(),
+    appUserMapper: z.nullable(AppUserMapper$inboundSchema).optional(),
     certifyPolicyId: z.nullable(z.string()).optional(),
     connectorVersion: z.nullable(z.number().int()).optional(),
     createdAt: z.nullable(
@@ -315,7 +315,7 @@ export function appFromJSON(
 /** @internal */
 export type AppInput$Outbound = {
   accessModel?: string | undefined;
-  appUserMapper?: AppUserMapper$Outbound | undefined;
+  appUserMapper?: AppUserMapper$Outbound | null | undefined;
   certifyPolicyId?: string | null | undefined;
   connectorVersion?: number | null | undefined;
   createdAt?: string | null | undefined;
@@ -343,7 +343,7 @@ export const AppInput$outboundSchema: z.ZodType<
   AppInput
 > = z.object({
   accessModel: AccessModel$outboundSchema.optional(),
-  appUserMapper: AppUserMapper$outboundSchema.optional(),
+  appUserMapper: z.nullable(AppUserMapper$outboundSchema).optional(),
   certifyPolicyId: z.nullable(z.string()).optional(),
   connectorVersion: z.nullable(z.number().int()).optional(),
   createdAt: z.nullable(z.date().transform(v => v.toISOString())).optional(),


### PR DESCRIPTION
Functions that list apps fail with a `ResponseValidationError` when any returned app has no custom account mapping configured.

## Problem

The API returns `appUserMapper: null` for any app without custom account mapping configured (the common case for most apps). The generated `App` Zod schema emitted:

```ts
appUserMapper: AppUserMapper$inboundSchema.optional(),   // accepts undefined, NOT null
```

So response validation throws on any response containing such an app, before any caller logic runs:

```
ZodError: [{ "code": "invalid_type", "expected": "object", "received": "null",
  "path": ["ListAppsResponse","list",0,"appUserMapper"] }]
```

## Root cause

The OpenAPI spec emits `appUserMapper` as a bare `$ref` to `AppUserMapper` with **no nullability**, and the hand-maintained `overlay.yaml` — which is where this repo adds nullability the spec lacks — had no entry for this message field. (Scalar fields like `appAccountId` and the array `appOwners` already get nullable treatment via the overlay; this single message field was simply missed.)

## Fix

Add the overlay action for `appUserMapper`, mirroring the existing nullable-`$ref` pattern already used for `notificationConfig` on `ConflictMonitor`:

```yaml
- target: $[...]["c1.api.app.v1.App"]["properties"]["appUserMapper"]
  update:
    oneOf:
      - $ref: "#/components/schemas/c1.api.app.v1.AppUserMapper"
      - type: "null"
- target: $[...]["c1.api.app.v1.App"]["properties"]["appUserMapper"]["$ref"]
  remove: true
```

The corresponding regenerated change to `src/sdk/models/shared/app.ts` is applied (inbound/outbound schemas → `z.nullable(...).optional()`, types → `| null | undefined`). I could not run `speakeasy run` here (it requires interactive registry auth), so the generated diff was applied by hand to match the `notificationConfig` precedent byte-for-byte — **please re-run the generator before release to confirm** it reproduces identically.

## Notes
- Any pending auto-regeneration PR will **not** fix this unless it includes this overlay change — regeneration against the current overlay reproduces the same bug. This overlay fix should land first.
- Systemic follow-up: because the nullable overlay is hand-maintained, any other single message-type (`$ref`) field added to the API since the overlay was last updated has the same latent bug. Worth an audit diffing `$ref` object properties against the overlay's `oneOf+null` entries.